### PR TITLE
refactor: rename station_sequence column to station_seq

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -24,7 +24,7 @@ class SubwayRouteStation(BaseModel):
     station_id: Mapped[str] = mapped_column(primary_key=True)
     route_id: Mapped[str] = mapped_column(ForeignKey("subway_route.route_id"), nullable=False)
     station_name: Mapped[str] = mapped_column(ForeignKey("subway_station.station_name"))
-    station_sequence: Mapped[int] = mapped_column(nullable=False)
+    station_seq: Mapped[int] = mapped_column(nullable=False)
     cumulative_time: Mapped[float] = mapped_column(nullable=False)
 
 

--- a/tests/insert_subway_information.py
+++ b/tests/insert_subway_information.py
@@ -65,7 +65,7 @@ async def insert_subway_station(db_session: Session):
                             station_id=station_number,
                             route_id=route_id,
                             station_name=station_name,
-                            station_sequence=row_index,
+                            station_seq=row_index,
                             cumulative_time=cumulative_time,
                         ),
                     )
@@ -82,7 +82,7 @@ async def insert_subway_station(db_session: Session):
             route_id=insert_statement.excluded.route_id,
             station_name=insert_statement.excluded.station_name,
             cumulative_time=insert_statement.excluded.cumulative_time,
-            station_sequence=insert_statement.excluded.station_sequence,
+            station_seq=insert_statement.excluded.station_seq,
         ),
     )
     db_session.execute(insert_statement)


### PR DESCRIPTION
## Summary

- Rename the `SubwayRouteStation.station_sequence` column mapping to `station_seq` to align with the shared database schema.
- Update the subway station test fixtures and the upsert `set_` clause to the new column name.

## Validation

- flake8 / mypy / pytest via the `code-check` workflow.
